### PR TITLE
Add support for SSH cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ $python lib/cve.py <tenant/managed> \
 }
 ```
 
+The CVE collector supports private repositories. First you need to specify a
+`--secretName` referencing a Kubernetes secret. The secret should
+be in the following form:
+
+```
+{
+  "kind": "Secret",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "cve-collectors-secret",
+    "namespace": "dev-release-team-tenant",
+  },
+  "data": {
+    "https://gitlab.com/my-group/my-repo": "c2NvdHRvCg==",
+    ...
+  },
+  "type": "Opaque"
+}
+```
+
+Each key on the secret should have a private key as value. If a key matches
+a repository listed in the snapshot related with the release, the private key
+is used for cloning the repository. The URL used for
+cloning with SSH is derived from the HTTPS URL of the repository, so
+`https://gitlab.com/my-group/my-repo` becomes `git@gitlab.com:my-group/my-repo`.
+The private key is passed using the environment variable `GIT_SSH_COMMAND`.
+
 ### Convert YAML to JASON
 
 This script gets a yaml file with jinja2 code and convert to json data.

--- a/tests/test_cve.py
+++ b/tests/test_cve.py
@@ -1,6 +1,7 @@
 import pytest
 import subprocess
-from lib.cve import create_cves_record
+from pathlib import Path
+from lib.cve import components_info, create_cves_record
 from lib.cve import git_log_titles_per_component
 
 mock_input =  {'comp1': ['CVE-1', 'CVE-3'],'comp2': ['CVE-2', 'CVE-4']}
@@ -39,27 +40,27 @@ class MockCompletedProcess:
 
 
 def test_git_log_success(monkeypatch):
-    def mock_subprocess_run(cmd, check, capture_output=True, text=True):
+    def mock_subprocess_run(cmd, check, capture_output=True, text=True, env={}):
         return MockCompletedProcess(returncode=0, stdout="\n".join(mock_list_titles_2), stderr="")
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-    res = git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677")
+    res = git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677", {})
     assert res == mock_titels2_result
 
 
 def test_git_log_empty_success(monkeypatch):
-    def mock_subprocess_run(cmd, check, capture_output=True, text=True):
+    def mock_subprocess_run(cmd, check, capture_output=True, text=True, env={}):
         return MockCompletedProcess(returncode=0, stdout="\n".join(mock_list_titles_1), stderr="")
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-    result = git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677")
+    result = git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677", {})
     assert result == mock_reponse_data_empty
 
 
 def test_git_log_fail(monkeypatch):
-    def mock_subprocess_run(cmd, check, capture_output=True, text=True):
+    def mock_subprocess_run(cmd, check, capture_output=True, text=True, env={}):
         return MockCompletedProcess(returncode=128, stdout="\n".join(mock_list_titles_2), stderr="")
     monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
     with pytest.raises(SystemExit):
-        git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677")
+        git_log_titles_per_component("https://mock-domain.com", "12345677", "23456677", {})
 
 
 def test_create_json_record(monkeypatch):


### PR DESCRIPTION
This PR introduces SSH cloning to the CVE collector so private repositories are supported. The script now takes a secret that contains URLs and private keys, so when it will clone a HTTPS repository that exists in that Secret it uses the private SSH key instead mangling the HTTPS URL to create an SSH one (`git@<host>:<path>`). 